### PR TITLE
fix : cpulimit.c:142:9: warning: argument 1 null where non-null expec…

### DIFF
--- a/cpulimit.c
+++ b/cpulimit.c
@@ -126,6 +126,7 @@ void checkExistsRunOnSem(void) {
                 duplCheckSem = NULL;
             }
             sem_unlink(psemName);
+            memset(psemName, 0x00, sizeof semName);
             return;
         }
 
@@ -139,6 +140,7 @@ void checkExistsRunOnSem(void) {
                     duplCheckSem = NULL;
                 }
                 sem_unlink(psemName);
+                memset(psemName, 0x00, sizeof semName);
             }
         } else {
             fprintf(stdout, "Another CPULimit daemon working.. (PID:%d), please first check it(1)\n", cpulimitPid);

--- a/cpulimit.c
+++ b/cpulimit.c
@@ -121,7 +121,10 @@ void checkExistsRunOnSem(void) {
         }
 
         if(0 < cpulimitPid && 0 == checkPid(cpulimitPid)) {       
-            sem_close(duplCheckSem);
+            if(duplCheckSem != NULL) {
+                sem_close(duplCheckSem);
+                duplCheckSem = NULL;
+            }
             sem_unlink(psemName);
             return;
         }
@@ -131,7 +134,10 @@ void checkExistsRunOnSem(void) {
                 fprintf(stdout, "System failure, Can not running with force mode, target pid : %d\n", cpulimitPid);
                 exit(1);
             } else {
-                sem_close(duplCheckSem);
+                if(duplCheckSem != NULL) {
+                    sem_close(duplCheckSem);
+                    duplCheckSem = NULL;
+                }
                 sem_unlink(psemName);
             }
         } else {
@@ -139,7 +145,10 @@ void checkExistsRunOnSem(void) {
             exit(1);
         }
     } else {
-        sem_close(duplCheckSem);
+        if(duplCheckSem != NULL) {
+            sem_close(duplCheckSem);
+            duplCheckSem = NULL;
+        }
     }
 }
 


### PR DESCRIPTION
FIX:

cpulimit.c:142:9: warning: argument 1 null where non-null expected [-Wnonnull]
  142 |         sem_close(duplCheckSem);
      |         ^~~~~~~~~~~~~~~~~~~~~~~
In file included from cpulimit.c:29:
/usr/include/semaphore.h:46:12: note: in a call to function ‘sem_close’ declared ‘nonnull’
   46 | extern int sem_close (sem_t *__sem) __THROW __nonnull ((1));
      |